### PR TITLE
Update client.lua

### DIFF
--- a/drp_bank/client.lua
+++ b/drp_bank/client.lua
@@ -58,10 +58,10 @@ Citizen.CreateThread(function()
         for a = 1, #atm_models do
             local atm = GetClosestObjectOfType(pedPos.x, pedPos.y, pedPos.z, 3.0, GetHashKey(atm_models[a]), false, 1, 1)
                 if atm ~= 0 and not atmOpen then
-                sleeper = 5 
+                sleeper = 7
                 local atmOffset = GetOffsetFromEntityInWorldCoords(atm, 0.0, -0.7, 0.0)
                 local atmHeading = GetEntityHeading(atm)
-                local distance = Vdist(pedPos.x, pedPos.y, pedPos.z, atmOffset.x, atmOffset.y, atmOffset.z)
+                local distance = Vdist2(pedPos.x, pedPos.y, pedPos.z, atmOffset.x, atmOffset.y, atmOffset.z)
                 -- DrawMarker(29, atmOffset.x, atmOffset.y, atmOffset.z + 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 30, 144, 255, 0.8, 1, 0, 0, 1, 0, 0, 0)
                 if distance <= 1.2 then
                     textDisplay("Press ~INPUT_PICKUP~ to use the ATM")


### PR DESCRIPTION
Sleeper on line 61 increased to 7 over 5 , The sleeper at 5 was causing 10MS when in range of the object we were trying to get distance from, The sleeper at 7 keeps this in a more manageable range of 5-6ms. https://prnt.sc/rj7hot This is just a cheap fix. Also using Vdist2 over Vdist as we dont need any sqrt in these checks for objects, so Vdist2 is actually a faster native.
Launder will need a fix too as it spikes to 15ms.
Rig is an I9-9900k and 2080ti , so performance spikes this high will be detrimental to lower end hardware if people just start mashing scripts together.